### PR TITLE
Update NixOS-WSL setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,10 +296,10 @@ In the case of [NixOS-WSL](https://github.com/nix-community/NixOS-WSL) (or any W
 
 ```powershell
 @echo off
-wsl -- "/usr/bin/browserpass 2>/dev/null"
+wsl -u user -- "/usr/bin/browserpass 2>/dev/null"
 ```
 
-With the `wsl` command, you can also specify the WSL distribution and the user executing the command:
+With the `wsl` command, you can also specify the WSL distribution executing the command:
 
 ```powershell
 wsl -d NixOS -u user -- "/usr/bin/browserpass 2>/dev/null"
@@ -311,7 +311,7 @@ It's worth noting that if Browserpass is installed in the user environment, the 
 
 ```powershell
 @echo off
-wsl -- "/home/user/.nix-profile/bin/browserpass 2>/dev/null"
+wsl -u user -- "/home/user/.nix-profile/bin/browserpass 2>/dev/null"
 ```
 
 ## Uninstallation


### PR DESCRIPTION
Minor changes to the NixOS-WSL setup. Due to issues with `systemd`, it is recommended to always specify the user. 